### PR TITLE
Add investment portfolio data structures and dashboard

### DIFF
--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/dao/CuentaInversionDAO.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/dao/CuentaInversionDAO.java
@@ -1,0 +1,142 @@
+package es.franciscorodalf.saveinvestor.backend.dao;
+
+import es.franciscorodalf.saveinvestor.backend.model.CuentaInversion;
+import es.franciscorodalf.saveinvestor.backend.model.CuentaInversion.TipoActivo;
+import es.franciscorodalf.saveinvestor.backend.model.abstractas.Conexion;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CuentaInversionDAO extends Conexion implements DAO<CuentaInversion> {
+
+    private CuentaInversion mapearCuenta(ResultSet rs) throws SQLException {
+        CuentaInversion cuenta = new CuentaInversion();
+        cuenta.setId(rs.getInt("id"));
+        cuenta.setUsuarioId(rs.getInt("usuario_id"));
+        cuenta.setNombre(rs.getString("nombre"));
+        cuenta.setTipoActivo(TipoActivo.fromDatabaseValue(rs.getString("tipo_activo")));
+        cuenta.setMoneda(rs.getString("moneda"));
+        cuenta.setValorInicial(rs.getDouble("valor_inicial"));
+        cuenta.setValorActual(rs.getDouble("valor_actual"));
+        Timestamp timestamp = rs.getTimestamp("fecha_creacion");
+        if (timestamp != null) {
+            cuenta.setFechaCreacion(timestamp.toLocalDateTime());
+        }
+        cuenta.setDescripcion(rs.getString("descripcion"));
+        return cuenta;
+    }
+
+    @Override
+    public void insertar(CuentaInversion cuenta) throws SQLException {
+        String sql = "INSERT INTO cuenta_inversion (usuario_id, nombre, tipo_activo, moneda, valor_inicial, valor_actual, fecha_creacion, descripcion) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setInt(1, cuenta.getUsuarioId());
+            stmt.setString(2, cuenta.getNombre());
+            stmt.setString(3, cuenta.getTipoActivo().toDatabaseValue());
+            stmt.setString(4, cuenta.getMoneda());
+            stmt.setDouble(5, cuenta.getValorInicial() != null ? cuenta.getValorInicial() : 0);
+            stmt.setDouble(6, cuenta.getValorActual() != null ? cuenta.getValorActual() : 0);
+            if (cuenta.getFechaCreacion() != null) {
+                stmt.setTimestamp(7, Timestamp.valueOf(cuenta.getFechaCreacion()));
+            } else {
+                stmt.setNull(7, Types.TIMESTAMP);
+            }
+            stmt.setString(8, cuenta.getDescripcion());
+            stmt.executeUpdate();
+
+            try (ResultSet rs = stmt.getGeneratedKeys()) {
+                if (rs.next()) {
+                    cuenta.setId(rs.getInt(1));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void actualizar(CuentaInversion cuenta) throws SQLException {
+        String sql = "UPDATE cuenta_inversion SET usuario_id = ?, nombre = ?, tipo_activo = ?, moneda = ?, valor_inicial = ?, valor_actual = ?, fecha_creacion = ?, descripcion = ? WHERE id = ?";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, cuenta.getUsuarioId());
+            stmt.setString(2, cuenta.getNombre());
+            stmt.setString(3, cuenta.getTipoActivo().toDatabaseValue());
+            stmt.setString(4, cuenta.getMoneda());
+            stmt.setDouble(5, cuenta.getValorInicial() != null ? cuenta.getValorInicial() : 0);
+            stmt.setDouble(6, cuenta.getValorActual() != null ? cuenta.getValorActual() : 0);
+            if (cuenta.getFechaCreacion() != null) {
+                stmt.setTimestamp(7, Timestamp.valueOf(cuenta.getFechaCreacion()));
+            } else {
+                stmt.setNull(7, Types.TIMESTAMP);
+            }
+            stmt.setString(8, cuenta.getDescripcion());
+            stmt.setInt(9, cuenta.getId());
+            stmt.executeUpdate();
+        }
+    }
+
+    @Override
+    public void eliminar(Integer id) throws SQLException {
+        String sql = "DELETE FROM cuenta_inversion WHERE id = ?";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            stmt.executeUpdate();
+        }
+    }
+
+    @Override
+    public CuentaInversion obtenerPorId(Integer id) throws SQLException {
+        String sql = "SELECT * FROM cuenta_inversion WHERE id = ?";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return mapearCuenta(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<CuentaInversion> obtenerTodos() throws SQLException {
+        String sql = "SELECT * FROM cuenta_inversion";
+        List<CuentaInversion> cuentas = new ArrayList<>();
+        try (PreparedStatement stmt = conectar().prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                cuentas.add(mapearCuenta(rs));
+            }
+        }
+        return cuentas;
+    }
+
+    public List<CuentaInversion> obtenerPorUsuario(Integer usuarioId) throws SQLException {
+        String sql = "SELECT * FROM cuenta_inversion WHERE usuario_id = ? ORDER BY fecha_creacion";
+        List<CuentaInversion> cuentas = new ArrayList<>();
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, usuarioId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    cuentas.add(mapearCuenta(rs));
+                }
+            }
+        }
+        return cuentas;
+    }
+
+    public void actualizarValorActual(Integer cuentaId, double nuevoValor) throws SQLException {
+        String sql = "UPDATE cuenta_inversion SET valor_actual = ?, fecha_creacion = COALESCE(fecha_creacion, ?) WHERE id = ?";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setDouble(1, nuevoValor);
+            stmt.setTimestamp(2, Timestamp.valueOf(LocalDateTime.now()));
+            stmt.setInt(3, cuentaId);
+            stmt.executeUpdate();
+        }
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/dao/MovimientoInversionDAO.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/dao/MovimientoInversionDAO.java
@@ -1,0 +1,142 @@
+package es.franciscorodalf.saveinvestor.backend.dao;
+
+import es.franciscorodalf.saveinvestor.backend.model.MovimientoInversion;
+import es.franciscorodalf.saveinvestor.backend.model.abstractas.Conexion;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MovimientoInversionDAO extends Conexion implements DAO<MovimientoInversion> {
+
+    private MovimientoInversion mapearMovimiento(ResultSet rs) throws SQLException {
+        MovimientoInversion movimiento = new MovimientoInversion();
+        movimiento.setId(rs.getInt("id"));
+        movimiento.setCuentaId(rs.getInt("cuenta_id"));
+        Timestamp timestamp = rs.getTimestamp("fecha");
+        if (timestamp != null) {
+            movimiento.setFecha(timestamp.toLocalDateTime());
+        }
+        movimiento.setAporte(rs.getDouble("aporte"));
+        movimiento.setRetiro(rs.getDouble("retiro"));
+        movimiento.setValorTotal(rs.getDouble("valor_total"));
+        movimiento.setRentabilidad(rs.getDouble("rentabilidad"));
+        movimiento.setNotas(rs.getString("notas"));
+        return movimiento;
+    }
+
+    @Override
+    public void insertar(MovimientoInversion movimiento) throws SQLException {
+        String sql = "INSERT INTO movimiento_inversion (cuenta_id, fecha, aporte, retiro, valor_total, rentabilidad, notas) VALUES (?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setInt(1, movimiento.getCuentaId());
+            if (movimiento.getFecha() != null) {
+                stmt.setTimestamp(2, Timestamp.valueOf(movimiento.getFecha()));
+            } else {
+                stmt.setNull(2, Types.TIMESTAMP);
+            }
+            stmt.setDouble(3, movimiento.getAporte() != null ? movimiento.getAporte() : 0);
+            stmt.setDouble(4, movimiento.getRetiro() != null ? movimiento.getRetiro() : 0);
+            stmt.setDouble(5, movimiento.getValorTotal());
+            stmt.setDouble(6, movimiento.getRentabilidad() != null ? movimiento.getRentabilidad() : 0);
+            stmt.setString(7, movimiento.getNotas());
+            stmt.executeUpdate();
+
+            try (ResultSet rs = stmt.getGeneratedKeys()) {
+                if (rs.next()) {
+                    movimiento.setId(rs.getInt(1));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void actualizar(MovimientoInversion movimiento) throws SQLException {
+        String sql = "UPDATE movimiento_inversion SET cuenta_id = ?, fecha = ?, aporte = ?, retiro = ?, valor_total = ?, rentabilidad = ?, notas = ? WHERE id = ?";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, movimiento.getCuentaId());
+            if (movimiento.getFecha() != null) {
+                stmt.setTimestamp(2, Timestamp.valueOf(movimiento.getFecha()));
+            } else {
+                stmt.setNull(2, Types.TIMESTAMP);
+            }
+            stmt.setDouble(3, movimiento.getAporte() != null ? movimiento.getAporte() : 0);
+            stmt.setDouble(4, movimiento.getRetiro() != null ? movimiento.getRetiro() : 0);
+            stmt.setDouble(5, movimiento.getValorTotal());
+            stmt.setDouble(6, movimiento.getRentabilidad() != null ? movimiento.getRentabilidad() : 0);
+            stmt.setString(7, movimiento.getNotas());
+            stmt.setInt(8, movimiento.getId());
+            stmt.executeUpdate();
+        }
+    }
+
+    @Override
+    public void eliminar(Integer id) throws SQLException {
+        String sql = "DELETE FROM movimiento_inversion WHERE id = ?";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            stmt.executeUpdate();
+        }
+    }
+
+    @Override
+    public MovimientoInversion obtenerPorId(Integer id) throws SQLException {
+        String sql = "SELECT * FROM movimiento_inversion WHERE id = ?";
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return mapearMovimiento(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<MovimientoInversion> obtenerTodos() throws SQLException {
+        String sql = "SELECT * FROM movimiento_inversion";
+        List<MovimientoInversion> movimientos = new ArrayList<>();
+        try (PreparedStatement stmt = conectar().prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                movimientos.add(mapearMovimiento(rs));
+            }
+        }
+        return movimientos;
+    }
+
+    public List<MovimientoInversion> obtenerPorCuenta(Integer cuentaId) throws SQLException {
+        String sql = "SELECT * FROM movimiento_inversion WHERE cuenta_id = ? ORDER BY fecha";
+        List<MovimientoInversion> movimientos = new ArrayList<>();
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, cuentaId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    movimientos.add(mapearMovimiento(rs));
+                }
+            }
+        }
+        return movimientos;
+    }
+
+    public List<MovimientoInversion> obtenerPorUsuario(Integer usuarioId) throws SQLException {
+        String sql = "SELECT mi.* FROM movimiento_inversion mi JOIN cuenta_inversion ci ON mi.cuenta_id = ci.id WHERE ci.usuario_id = ? ORDER BY mi.fecha";
+        List<MovimientoInversion> movimientos = new ArrayList<>();
+        try (PreparedStatement stmt = conectar().prepareStatement(sql)) {
+            stmt.setInt(1, usuarioId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    movimientos.add(mapearMovimiento(rs));
+                }
+            }
+        }
+        return movimientos;
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/model/CuentaInversion.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/model/CuentaInversion.java
@@ -1,0 +1,147 @@
+package es.franciscorodalf.saveinvestor.backend.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class CuentaInversion {
+
+    public enum TipoActivo {
+        AHORRO,
+        FONDO,
+        CRYPTO;
+
+        public static TipoActivo fromDatabaseValue(String value) {
+            if (value == null) {
+                throw new IllegalArgumentException("El tipo de activo no puede ser nulo");
+            }
+            return TipoActivo.valueOf(value.toUpperCase());
+        }
+
+        public String toDatabaseValue() {
+            return name();
+        }
+    }
+
+    private Integer id;
+    private Integer usuarioId;
+    private String nombre;
+    private TipoActivo tipoActivo;
+    private String moneda;
+    private Double valorInicial;
+    private Double valorActual;
+    private LocalDateTime fechaCreacion;
+    private String descripcion;
+
+    public CuentaInversion() {
+    }
+
+    public CuentaInversion(Integer usuarioId, String nombre, TipoActivo tipoActivo) {
+        this.usuarioId = usuarioId;
+        this.nombre = nombre;
+        this.tipoActivo = tipoActivo;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getUsuarioId() {
+        return usuarioId;
+    }
+
+    public void setUsuarioId(Integer usuarioId) {
+        this.usuarioId = usuarioId;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public TipoActivo getTipoActivo() {
+        return tipoActivo;
+    }
+
+    public void setTipoActivo(TipoActivo tipoActivo) {
+        this.tipoActivo = tipoActivo;
+    }
+
+    public String getMoneda() {
+        return moneda;
+    }
+
+    public void setMoneda(String moneda) {
+        this.moneda = moneda;
+    }
+
+    public Double getValorInicial() {
+        return valorInicial;
+    }
+
+    public void setValorInicial(Double valorInicial) {
+        this.valorInicial = valorInicial;
+    }
+
+    public Double getValorActual() {
+        return valorActual;
+    }
+
+    public void setValorActual(Double valorActual) {
+        this.valorActual = valorActual;
+    }
+
+    public LocalDateTime getFechaCreacion() {
+        return fechaCreacion;
+    }
+
+    public void setFechaCreacion(LocalDateTime fechaCreacion) {
+        this.fechaCreacion = fechaCreacion;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CuentaInversion)) {
+            return false;
+        }
+        CuentaInversion that = (CuentaInversion) o;
+        return Objects.equals(id, that.id) && Objects.equals(usuarioId, that.usuarioId) && Objects.equals(nombre, that.nombre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, usuarioId, nombre);
+    }
+
+    @Override
+    public String toString() {
+        return "CuentaInversion{" +
+                "id=" + id +
+                ", usuarioId=" + usuarioId +
+                ", nombre='" + nombre + '\'' +
+                ", tipoActivo=" + tipoActivo +
+                ", moneda='" + moneda + '\'' +
+                ", valorInicial=" + valorInicial +
+                ", valorActual=" + valorActual +
+                ", fechaCreacion=" + fechaCreacion +
+                ", descripcion='" + descripcion + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/model/MovimientoInversion.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/model/MovimientoInversion.java
@@ -1,0 +1,119 @@
+package es.franciscorodalf.saveinvestor.backend.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class MovimientoInversion {
+    private Integer id;
+    private Integer cuentaId;
+    private LocalDateTime fecha;
+    private Double aporte;
+    private Double retiro;
+    private Double valorTotal;
+    private Double rentabilidad;
+    private String notas;
+
+    public MovimientoInversion() {
+    }
+
+    public MovimientoInversion(Integer cuentaId, LocalDateTime fecha, Double valorTotal) {
+        this.cuentaId = cuentaId;
+        this.fecha = fecha;
+        this.valorTotal = valorTotal;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getCuentaId() {
+        return cuentaId;
+    }
+
+    public void setCuentaId(Integer cuentaId) {
+        this.cuentaId = cuentaId;
+    }
+
+    public LocalDateTime getFecha() {
+        return fecha;
+    }
+
+    public void setFecha(LocalDateTime fecha) {
+        this.fecha = fecha;
+    }
+
+    public Double getAporte() {
+        return aporte;
+    }
+
+    public void setAporte(Double aporte) {
+        this.aporte = aporte;
+    }
+
+    public Double getRetiro() {
+        return retiro;
+    }
+
+    public void setRetiro(Double retiro) {
+        this.retiro = retiro;
+    }
+
+    public Double getValorTotal() {
+        return valorTotal;
+    }
+
+    public void setValorTotal(Double valorTotal) {
+        this.valorTotal = valorTotal;
+    }
+
+    public Double getRentabilidad() {
+        return rentabilidad;
+    }
+
+    public void setRentabilidad(Double rentabilidad) {
+        this.rentabilidad = rentabilidad;
+    }
+
+    public String getNotas() {
+        return notas;
+    }
+
+    public void setNotas(String notas) {
+        this.notas = notas;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MovimientoInversion)) {
+            return false;
+        }
+        MovimientoInversion that = (MovimientoInversion) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "MovimientoInversion{" +
+                "id=" + id +
+                ", cuentaId=" + cuentaId +
+                ", fecha=" + fecha +
+                ", aporte=" + aporte +
+                ", retiro=" + retiro +
+                ", valorTotal=" + valorTotal +
+                ", rentabilidad=" + rentabilidad +
+                ", notas='" + notas + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/model/ValorHistoricoInversion.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/model/ValorHistoricoInversion.java
@@ -1,0 +1,21 @@
+package es.franciscorodalf.saveinvestor.backend.model;
+
+import java.time.LocalDate;
+
+public class ValorHistoricoInversion {
+    private final LocalDate fecha;
+    private final double valorTotal;
+
+    public ValorHistoricoInversion(LocalDate fecha, double valorTotal) {
+        this.fecha = fecha;
+        this.valorTotal = valorTotal;
+    }
+
+    public LocalDate getFecha() {
+        return fecha;
+    }
+
+    public double getValorTotal() {
+        return valorTotal;
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/service/PortafolioService.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/service/PortafolioService.java
@@ -1,0 +1,88 @@
+package es.franciscorodalf.saveinvestor.backend.service;
+
+import es.franciscorodalf.saveinvestor.backend.dao.CuentaInversionDAO;
+import es.franciscorodalf.saveinvestor.backend.dao.MovimientoInversionDAO;
+import es.franciscorodalf.saveinvestor.backend.model.CuentaInversion;
+import es.franciscorodalf.saveinvestor.backend.model.CuentaInversion.TipoActivo;
+import es.franciscorodalf.saveinvestor.backend.model.MovimientoInversion;
+import es.franciscorodalf.saveinvestor.backend.model.ValorHistoricoInversion;
+
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PortafolioService {
+
+    private final CuentaInversionDAO cuentaDAO;
+    private final MovimientoInversionDAO movimientoDAO;
+
+    public PortafolioService() {
+        this(new CuentaInversionDAO(), new MovimientoInversionDAO());
+    }
+
+    public PortafolioService(CuentaInversionDAO cuentaDAO, MovimientoInversionDAO movimientoDAO) {
+        this.cuentaDAO = cuentaDAO;
+        this.movimientoDAO = movimientoDAO;
+    }
+
+    public Map<TipoActivo, Double> calcularDistribucionPorTipo(Integer usuarioId) throws SQLException {
+        List<CuentaInversion> cuentas = cuentaDAO.obtenerPorUsuario(usuarioId);
+        Map<TipoActivo, Double> distribucion = new EnumMap<>(TipoActivo.class);
+        for (CuentaInversion cuenta : cuentas) {
+            double valor = cuenta.getValorActual() != null ? cuenta.getValorActual() : 0d;
+            distribucion.merge(cuenta.getTipoActivo(), valor, Double::sum);
+        }
+        return distribucion;
+    }
+
+    public double obtenerValorActualTotal(Integer usuarioId) throws SQLException {
+        List<CuentaInversion> cuentas = cuentaDAO.obtenerPorUsuario(usuarioId);
+        return cuentas.stream()
+                .map(CuentaInversion::getValorActual)
+                .filter(valor -> valor != null)
+                .mapToDouble(Double::doubleValue)
+                .sum();
+    }
+
+    public List<ValorHistoricoInversion> obtenerRendimientoHistorico(Integer usuarioId) throws SQLException {
+        List<MovimientoInversion> movimientos = new ArrayList<>(movimientoDAO.obtenerPorUsuario(usuarioId));
+        movimientos.sort(Comparator.comparing(movimiento -> {
+            if (movimiento.getFecha() == null) {
+                return LocalDate.now().atStartOfDay();
+            }
+            return movimiento.getFecha();
+        }));
+
+        Map<Integer, Double> ultimoValorPorCuenta = new HashMap<>();
+        Map<LocalDate, Double> valorPorFecha = new LinkedHashMap<>();
+
+        for (MovimientoInversion movimiento : movimientos) {
+            LocalDate fecha = movimiento.getFecha() != null ? movimiento.getFecha().toLocalDate() : LocalDate.now();
+            ultimoValorPorCuenta.put(movimiento.getCuentaId(), movimiento.getValorTotal());
+            double total = ultimoValorPorCuenta.values().stream().mapToDouble(Double::doubleValue).sum();
+            valorPorFecha.put(fecha, total);
+        }
+
+        if (valorPorFecha.isEmpty()) {
+            double totalActual = obtenerValorActualTotal(usuarioId);
+            if (totalActual > 0) {
+                valorPorFecha.put(LocalDate.now(), totalActual);
+            }
+        }
+
+        return valorPorFecha.entrySet().stream()
+                .map(entry -> new ValorHistoricoInversion(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    public List<CuentaInversion> obtenerCuentasPorUsuario(Integer usuarioId) throws SQLException {
+        return cuentaDAO.obtenerPorUsuario(usuarioId);
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/MainController.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/MainController.java
@@ -37,7 +37,10 @@ public class MainController {
     
     @FXML
     private Button btnObjetivos;
-    
+
+    @FXML
+    private Button btnPortafolio;
+
     @FXML
     private Button btnGasto;
     
@@ -281,6 +284,11 @@ public class MainController {
     private void onObjetivos(ActionEvent event) {
         cambiarEscena(event, "/es/franciscorodalf/saveinvestor/objetivos.fxml");
     }
+
+    @FXML
+    private void onPortafolio(ActionEvent event) {
+        cambiarEscena(event, "/es/franciscorodalf/saveinvestor/portafolio.fxml");
+    }
     
     @FXML
     private void onRegistrarGasto(ActionEvent event) {
@@ -380,6 +388,8 @@ public class MainController {
                     ((ObjetivosController) controller).setUsuario(usuarioActual);
                 } else if (controller instanceof EstadisticasController) {
                     ((EstadisticasController) controller).setUsuario(usuarioActual);
+                } else if (controller instanceof PortafolioController) {
+                    ((PortafolioController) controller).setUsuario(usuarioActual);
                 }
             }
             

--- a/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/PortafolioController.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/PortafolioController.java
@@ -1,0 +1,163 @@
+package es.franciscorodalf.saveinvestor.frontend.controller;
+
+import es.franciscorodalf.saveinvestor.backend.model.CuentaInversion.TipoActivo;
+import es.franciscorodalf.saveinvestor.backend.model.Usuario;
+import es.franciscorodalf.saveinvestor.backend.model.ValorHistoricoInversion;
+import es.franciscorodalf.saveinvestor.backend.service.PortafolioService;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.PieChart;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class PortafolioController {
+
+    @FXML
+    private LineChart<String, Number> lineRendimiento;
+
+    @FXML
+    private PieChart pieDistribucion;
+
+    @FXML
+    private Label lblValorTotal;
+
+    @FXML
+    private Label lblMensaje;
+
+    private Usuario usuarioActual;
+    private PortafolioService portafolioService;
+
+    @FXML
+    private void initialize() {
+        portafolioService = new PortafolioService();
+        lineRendimiento.setAnimated(false);
+        pieDistribucion.setAnimated(false);
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuarioActual = usuario;
+        cargarDatosPortafolio();
+    }
+
+    private void cargarDatosPortafolio() {
+        if (usuarioActual == null || usuarioActual.getId() == null) {
+            lblMensaje.setText("No se pudo determinar el usuario activo.");
+            return;
+        }
+
+        try {
+            double valorTotal = portafolioService.obtenerValorActualTotal(usuarioActual.getId());
+            lblValorTotal.setText(String.format(Locale.getDefault(), "Valor total actual: %.2f", valorTotal));
+
+            cargarRendimientoHistorico(portafolioService.obtenerRendimientoHistorico(usuarioActual.getId()));
+            cargarDistribucion(portafolioService.calcularDistribucionPorTipo(usuarioActual.getId()));
+
+            if (!lineRendimiento.isVisible() && !pieDistribucion.isVisible()) {
+                lblMensaje.setText("No hay datos de inversiones disponibles. Registra aportes para visualizar el portafolio.");
+            } else {
+                lblMensaje.setText("");
+            }
+        } catch (SQLException e) {
+            lblMensaje.setText("Error al cargar el portafolio: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void cargarRendimientoHistorico(List<ValorHistoricoInversion> valores) {
+        lineRendimiento.getData().clear();
+        if (valores == null || valores.isEmpty()) {
+            lineRendimiento.setVisible(false);
+            lineRendimiento.setManaged(false);
+            return;
+        }
+
+        lineRendimiento.setVisible(true);
+        lineRendimiento.setManaged(true);
+        XYChart.Series<String, Number> serie = new XYChart.Series<>();
+        serie.setName("Valor del portafolio");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault());
+        for (ValorHistoricoInversion valor : valores) {
+            serie.getData().add(new XYChart.Data<>(valor.getFecha().format(formatter), valor.getValorTotal()));
+        }
+        lineRendimiento.getData().add(serie);
+    }
+
+    private void cargarDistribucion(Map<TipoActivo, Double> distribucion) {
+        pieDistribucion.getData().clear();
+        if (distribucion == null || distribucion.isEmpty()) {
+            pieDistribucion.setVisible(false);
+            pieDistribucion.setManaged(false);
+            return;
+        }
+
+        double total = distribucion.values().stream().mapToDouble(Double::doubleValue).sum();
+        if (total <= 0) {
+            pieDistribucion.setVisible(false);
+            pieDistribucion.setManaged(false);
+            return;
+        }
+
+        ObservableList<PieChart.Data> datos = FXCollections.observableArrayList();
+        distribucion.forEach((tipo, valor) -> {
+            double porcentaje = (valor / total) * 100;
+            String etiqueta = String.format(Locale.getDefault(), "%s (%.1f%%)", formatearTipo(tipo), porcentaje);
+            datos.add(new PieChart.Data(etiqueta, valor));
+        });
+
+        pieDistribucion.setData(datos);
+        pieDistribucion.setVisible(true);
+        pieDistribucion.setManaged(true);
+    }
+
+    private String formatearTipo(TipoActivo tipo) {
+        switch (tipo) {
+            case AHORRO:
+                return "Ahorro";
+            case FONDO:
+                return "Fondos";
+            case CRYPTO:
+                return "Criptomonedas";
+            default:
+                return tipo.name();
+        }
+    }
+
+    @FXML
+    private void onVolver(ActionEvent event) {
+        cambiarEscena(event, "/es/franciscorodalf/saveinvestor/main.fxml");
+    }
+
+    private void cambiarEscena(ActionEvent event, String fxml) {
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource(fxml));
+            Parent root = loader.load();
+
+            if (fxml.contains("main.fxml") && usuarioActual != null) {
+                MainController controller = loader.getController();
+                controller.setUsuario(usuarioActual);
+            }
+
+            Stage stage = (Stage) ((Node) event.getSource()).getScene().getWindow();
+            stage.setScene(new Scene(root));
+            stage.show();
+        } catch (IOException e) {
+            lblMensaje.setText("No se pudo cambiar la vista: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/resources/database/setup.sql
+++ b/src/main/resources/database/setup.sql
@@ -29,6 +29,33 @@ CREATE TABLE IF NOT EXISTS estadistica (
     FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
 );
 
+-- Tabla de cuentas de inversión (ahorro, fondos y criptomonedas)
+CREATE TABLE IF NOT EXISTS cuenta_inversion (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    usuario_id INTEGER NOT NULL,
+    nombre TEXT NOT NULL,
+    tipo_activo TEXT NOT NULL CHECK (tipo_activo IN ('AHORRO', 'FONDO', 'CRYPTO')),
+    moneda TEXT NOT NULL DEFAULT 'EUR',
+    valor_inicial REAL NOT NULL DEFAULT 0,
+    valor_actual REAL NOT NULL DEFAULT 0,
+    fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    descripcion TEXT,
+    FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE CASCADE
+);
+
+-- Tabla de movimientos y valoraciones históricas de las cuentas de inversión
+CREATE TABLE IF NOT EXISTS movimiento_inversion (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cuenta_id INTEGER NOT NULL,
+    fecha TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    aporte REAL DEFAULT 0,
+    retiro REAL DEFAULT 0,
+    valor_total REAL NOT NULL,
+    rentabilidad REAL DEFAULT 0,
+    notas TEXT,
+    FOREIGN KEY (cuenta_id) REFERENCES cuenta_inversion(id) ON DELETE CASCADE
+);
+
 -- Tabla de objetivos financieros
 CREATE TABLE IF NOT EXISTS objetivo (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -48,6 +75,10 @@ CREATE INDEX IF NOT EXISTS idx_tarea_fecha ON tarea(fecha);
 CREATE INDEX IF NOT EXISTS idx_tarea_estado ON tarea(estado);
 CREATE INDEX IF NOT EXISTS idx_objetivo_usuario ON objetivo(usuario_id);
 CREATE INDEX IF NOT EXISTS idx_objetivo_completado ON objetivo(completado);
+CREATE INDEX IF NOT EXISTS idx_cuenta_inversion_usuario ON cuenta_inversion(usuario_id);
+CREATE INDEX IF NOT EXISTS idx_cuenta_inversion_tipo ON cuenta_inversion(tipo_activo);
+CREATE INDEX IF NOT EXISTS idx_movimiento_inversion_cuenta ON movimiento_inversion(cuenta_id);
+CREATE INDEX IF NOT EXISTS idx_movimiento_inversion_fecha ON movimiento_inversion(fecha);
 
 -- Los triggers están comentados para evitar la doble actualización
 /*
@@ -129,10 +160,28 @@ INSERT OR IGNORE INTO estadistica (usuario_id, total_ingreso, total_gasto)
 VALUES (1, 0, 0);
 
 -- Insertar algunas tareas de ejemplo
-INSERT OR IGNORE INTO tarea (id, concepto, cantidad, fecha, estado, usuario_id) VALUES 
+INSERT OR IGNORE INTO tarea (id, concepto, cantidad, fecha, estado, usuario_id) VALUES
 (1, 'Salario', 1500.0, CURRENT_TIMESTAMP, 'INGRESO', 1),
 (2, 'Alquiler', 700.0, CURRENT_TIMESTAMP, 'GASTO', 1),
 (3, 'Compra supermercado', 150.0, CURRENT_TIMESTAMP, 'GASTO', 1);
+
+-- Insertar cuentas de inversión de ejemplo
+INSERT OR IGNORE INTO cuenta_inversion (id, usuario_id, nombre, tipo_activo, moneda, valor_inicial, valor_actual, descripcion) VALUES
+(1, 1, 'Cuenta de Ahorro Principal', 'AHORRO', 'EUR', 500.0, 1250.0, 'Cuenta de ahorro para emergencias'),
+(2, 1, 'Fondo Indexado Global', 'FONDO', 'EUR', 1000.0, 1850.0, 'Inversión en ETF global'),
+(3, 1, 'Wallet Cripto', 'CRYPTO', 'USD', 300.0, 720.0, 'Portafolio diversificado de criptomonedas');
+
+-- Insertar movimientos históricos de ejemplo para las cuentas
+INSERT OR IGNORE INTO movimiento_inversion (id, cuenta_id, fecha, aporte, retiro, valor_total, rentabilidad, notas) VALUES
+(1, 1, datetime('now', '-90 day'), 200.0, 0.0, 650.0, 0.012, 'Depósito inicial y primer rendimiento'),
+(2, 1, datetime('now', '-30 day'), 100.0, 0.0, 900.0, 0.008, 'Incremento de saldo'),
+(3, 1, datetime('now'), 0.0, 0.0, 1250.0, 0.006, 'Interés mensual acumulado'),
+(4, 2, datetime('now', '-120 day'), 1000.0, 0.0, 1050.0, 0.020, 'Compra inicial del fondo'),
+(5, 2, datetime('now', '-60 day'), 0.0, 0.0, 1500.0, 0.035, 'Revalorización del mercado'),
+(6, 2, datetime('now'), 0.0, 0.0, 1850.0, 0.012, 'Último valor liquidativo'),
+(7, 3, datetime('now', '-45 day'), 300.0, 0.0, 480.0, 0.080, 'Compra inicial de criptomonedas'),
+(8, 3, datetime('now', '-15 day'), 0.0, 50.0, 620.0, -0.025, 'Venta parcial para asegurar ganancias'),
+(9, 3, datetime('now'), 0.0, 0.0, 720.0, 0.045, 'Apreciación reciente del mercado');
 
 -- Insertar objetivo de ejemplo
 INSERT OR IGNORE INTO objetivo (id, descripcion, cantidad_objetivo, cantidad_actual, usuario_id) VALUES

--- a/src/main/resources/es/franciscorodalf/saveinvestor/main.fxml
+++ b/src/main/resources/es/franciscorodalf/saveinvestor/main.fxml
@@ -68,6 +68,7 @@
             <Button fx:id="btnCerrarSesion" onAction="#onCerrarSesion" style="-fx-text-fill: #E74C3C;" text="Cerrar Sesión" />
             <Button fx:id="btnEstadisticas" onAction="#onEstadisticas" text="Estadísticas" />
             <Button fx:id="btnObjetivos" onAction="#onObjetivos" text="Objetivos" />
+            <Button fx:id="btnPortafolio" onAction="#onPortafolio" text="Portafolio" />
         </HBox>
     </bottom>
 

--- a/src/main/resources/es/franciscorodalf/saveinvestor/portafolio.fxml
+++ b/src/main/resources/es/franciscorodalf/saveinvestor/portafolio.fxml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.chart.CategoryAxis?>
+<?import javafx.scene.chart.LineChart?>
+<?import javafx.scene.chart.NumberAxis?>
+<?import javafx.scene.chart.PieChart?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<BorderPane prefHeight="720.0" prefWidth="1024.0" style="-fx-background-color: #f5f5f5;" stylesheets="@../../../styles/style.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="es.franciscorodalf.saveinvestor.frontend.controller.PortafolioController">
+    <top>
+        <HBox alignment="CENTER_LEFT" spacing="10">
+            <padding>
+                <Insets bottom="15" left="15" right="15" top="15" />
+            </padding>
+            <Button fx:id="btnVolver" mnemonicParsing="false" onAction="#onVolver" text="Regresar" />
+            <Label fx:id="lblTitulo" style="-fx-font-size: 20px; -fx-font-weight: bold;" text="Resumen del portafolio" />
+        </HBox>
+    </top>
+    <center>
+        <VBox alignment="TOP_CENTER" spacing="20">
+            <padding>
+                <Insets bottom="20" left="20" right="20" top="20" />
+            </padding>
+            <Label fx:id="lblValorTotal" style="-fx-font-size: 18px; -fx-font-weight: bold;" text="Valor total actual: --" />
+            <LineChart fx:id="lineRendimiento" prefHeight="320.0" prefWidth="880.0" title="Evolución histórica" >
+                <xAxis>
+                    <CategoryAxis label="Fecha" />
+                </xAxis>
+                <yAxis>
+                    <NumberAxis label="Valor total" />
+                </yAxis>
+            </LineChart>
+            <PieChart fx:id="pieDistribucion" labelsVisible="true" prefHeight="260.0" prefWidth="420.0" title="Distribución por tipo de activo" />
+            <Label fx:id="lblMensaje" style="-fx-text-fill: #7f8c8d;" text="" wrapText="true" />
+        </VBox>
+    </center>
+</BorderPane>


### PR DESCRIPTION
## Summary
- add database tables and seed data for investment accounts and their historical valuations
- implement portfolio models, DAOs, and services to calculate asset distribution and historical performance
- build a JavaFX portfolio view with charts and hook it into the main controller

## Testing
- mvn -q -DskipTests package *(fails: could not resolve org.openjfx:javafx-maven-plugin due to HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e44e52868832d888e14bffa95c8d4)