### PR TITLE
Add savings goal simulator service and UI

### DIFF
--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/service/PuntoProyeccion.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/service/PuntoProyeccion.java
@@ -1,0 +1,8 @@
+package es.franciscorodalf.saveinvestor.backend.service;
+
+/**
+ * Representa un punto dentro de la proyección mensual generada por el
+ * simulador de metas.
+ */
+public record PuntoProyeccion(int periodo, double saldo, double aporteAcumulado, double interesAcumulado) {
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/service/SimulacionMetaResultado.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/service/SimulacionMetaResultado.java
@@ -1,0 +1,56 @@
+package es.franciscorodalf.saveinvestor.backend.service;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Resultado de una simulación de metas que incluye los datos agregados y la
+ * serie de puntos que componen la proyección.
+ */
+public class SimulacionMetaResultado {
+
+    private final List<PuntoProyeccion> puntos;
+    private final double saldoFinal;
+    private final double totalAportado;
+    private final double totalIntereses;
+    private final Integer periodoAlcanceMeta;
+    private final Double metaObjetivo;
+
+    public SimulacionMetaResultado(List<PuntoProyeccion> puntos,
+                                   double saldoFinal,
+                                   double totalAportado,
+                                   double totalIntereses,
+                                   Integer periodoAlcanceMeta,
+                                   Double metaObjetivo) {
+        this.puntos = Collections.unmodifiableList(puntos);
+        this.saldoFinal = saldoFinal;
+        this.totalAportado = totalAportado;
+        this.totalIntereses = totalIntereses;
+        this.periodoAlcanceMeta = periodoAlcanceMeta;
+        this.metaObjetivo = metaObjetivo;
+    }
+
+    public List<PuntoProyeccion> getPuntos() {
+        return puntos;
+    }
+
+    public double getSaldoFinal() {
+        return saldoFinal;
+    }
+
+    public double getTotalAportado() {
+        return totalAportado;
+    }
+
+    public double getTotalIntereses() {
+        return totalIntereses;
+    }
+
+    public Integer getPeriodoAlcanceMeta() {
+        return periodoAlcanceMeta;
+    }
+
+    public Double getMetaObjetivo() {
+        return metaObjetivo;
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/backend/service/SimuladorMetasService.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/backend/service/SimuladorMetasService.java
@@ -1,0 +1,109 @@
+package es.franciscorodalf.saveinvestor.backend.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Servicio encargado de calcular proyecciones de ahorro para metas
+ * financieras considerando tasas de interés compuestas, aportaciones
+ * periódicas y horizonte temporal.
+ */
+public class SimuladorMetasService {
+
+    /**
+     * Genera una proyección mensual de ahorro.
+     *
+     * @param montoInicial        capital inicial disponible
+     * @param aportacionPeriodica ahorro que se aportará cada mes
+     * @param tasaInteresAnual    tasa de interés anual en formato decimal (0.05 = 5%)
+     * @param horizonteMeses      número de meses a simular
+     * @param metaObjetivo        monto objetivo opcional para calcular cuándo se alcanza
+     * @return resultado con la información acumulada de la simulación
+     */
+    public SimulacionMetaResultado simular(double montoInicial,
+                                           double aportacionPeriodica,
+                                           double tasaInteresAnual,
+                                           int horizonteMeses,
+                                           Double metaObjetivo) {
+        if (montoInicial < 0 || aportacionPeriodica < 0) {
+            throw new IllegalArgumentException("Los montos no pueden ser negativos");
+        }
+        if (tasaInteresAnual < -0.999) {
+            throw new IllegalArgumentException("La tasa anual no puede ser menor a -99.9%");
+        }
+        if (horizonteMeses <= 0) {
+            throw new IllegalArgumentException("El horizonte debe ser mayor a cero");
+        }
+
+        double tasaMensual = calcularTasaMensual(tasaInteresAnual);
+        double saldo = montoInicial;
+        double totalAportado = montoInicial;
+        double interesesAcumulados = 0;
+        Integer periodoAlcance = null;
+
+        List<PuntoProyeccion> puntos = new ArrayList<>();
+        puntos.add(new PuntoProyeccion(0, redondear(saldo), redondear(totalAportado), redondear(interesesAcumulados)));
+
+        for (int mes = 1; mes <= horizonteMeses; mes++) {
+            saldo += aportacionPeriodica;
+            totalAportado += aportacionPeriodica;
+
+            double interesMes = saldo * tasaMensual;
+            interesesAcumulados += interesMes;
+            saldo += interesMes;
+
+            if (metaObjetivo != null && periodoAlcance == null && saldo >= metaObjetivo) {
+                periodoAlcance = mes;
+            }
+
+            puntos.add(new PuntoProyeccion(mes, redondear(saldo), redondear(totalAportado), redondear(interesesAcumulados)));
+        }
+
+        return new SimulacionMetaResultado(puntos,
+                redondear(saldo),
+                redondear(totalAportado),
+                redondear(interesesAcumulados),
+                periodoAlcance,
+                metaObjetivo);
+    }
+
+    /**
+     * Calcula la aportación periódica necesaria para alcanzar un objetivo.
+     *
+     * @param montoInicial     capital inicial disponible
+     * @param tasaInteresAnual tasa de interés anual (decimal)
+     * @param horizonteMeses   meses en los que se quiere alcanzar la meta
+     * @param metaObjetivo     monto objetivo
+     * @return aportación mensual recomendada
+     */
+    public double calcularAportacionNecesaria(double montoInicial,
+                                              double tasaInteresAnual,
+                                              int horizonteMeses,
+                                              double metaObjetivo) {
+        if (metaObjetivo <= 0) {
+            throw new IllegalArgumentException("La meta debe ser mayor a cero");
+        }
+        if (horizonteMeses <= 0) {
+            throw new IllegalArgumentException("El horizonte debe ser mayor a cero");
+        }
+
+        double tasaMensual = calcularTasaMensual(tasaInteresAnual);
+        double factorCapitalizado = Math.pow(1 + tasaMensual, horizonteMeses);
+        double valorObjetivo = metaObjetivo - montoInicial * factorCapitalizado;
+
+        if (Math.abs(tasaMensual) < 1e-9) {
+            return redondear(valorObjetivo / horizonteMeses);
+        }
+
+        double aportacion = valorObjetivo * tasaMensual / (factorCapitalizado - 1);
+        return redondear(aportacion);
+    }
+
+    private double calcularTasaMensual(double tasaInteresAnual) {
+        return Math.pow(1 + tasaInteresAnual, 1.0 / 12) - 1;
+    }
+
+    private double redondear(double valor) {
+        return Math.round(valor * 100.0) / 100.0;
+    }
+}

--- a/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/MainController.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/MainController.java
@@ -281,7 +281,27 @@ public class MainController {
     private void onObjetivos(ActionEvent event) {
         cambiarEscena(event, "/es/franciscorodalf/saveinvestor/objetivos.fxml");
     }
-    
+
+    @FXML
+    private void onSimulador(ActionEvent event) {
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/es/franciscorodalf/saveinvestor/simuladorMetas.fxml"));
+            Parent root = loader.load();
+
+            SimuladorMetasController controller = loader.getController();
+            if (controller != null && usuarioActual != null) {
+                controller.setUsuario(usuarioActual);
+                controller.setRutaRetorno("/es/franciscorodalf/saveinvestor/main.fxml");
+            }
+
+            Stage stage = (Stage) ((Node) event.getSource()).getScene().getWindow();
+            stage.setScene(new Scene(root));
+            stage.show();
+        } catch (IOException e) {
+            System.err.println("Error al cargar el simulador: " + e.getMessage());
+        }
+    }
+
     @FXML
     private void onRegistrarGasto(ActionEvent event) {
         try {
@@ -380,6 +400,9 @@ public class MainController {
                     ((ObjetivosController) controller).setUsuario(usuarioActual);
                 } else if (controller instanceof EstadisticasController) {
                     ((EstadisticasController) controller).setUsuario(usuarioActual);
+                } else if (controller instanceof SimuladorMetasController) {
+                    ((SimuladorMetasController) controller).setUsuario(usuarioActual);
+                    ((SimuladorMetasController) controller).setRutaRetorno("/es/franciscorodalf/saveinvestor/main.fxml");
                 }
             }
             

--- a/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/ObjetivosController.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/ObjetivosController.java
@@ -473,7 +473,32 @@ public class ObjetivosController {
 
     /**
      * Maneja el evento del botón volver
-     * 
+     *
+     * @param event El evento de acción
+     */
+    @FXML
+    private void onAbrirSimulador(ActionEvent event) {
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/es/franciscorodalf/saveinvestor/simuladorMetas.fxml"));
+            Parent root = loader.load();
+
+            SimuladorMetasController controller = loader.getController();
+            if (controller != null) {
+                controller.setUsuario(usuarioActual);
+                controller.setRutaRetorno("/es/franciscorodalf/saveinvestor/objetivos.fxml");
+            }
+
+            Stage stage = (Stage) ((Node) event.getSource()).getScene().getWindow();
+            stage.setScene(new Scene(root));
+            stage.show();
+        } catch (IOException e) {
+            mostrarMensaje("No se pudo abrir el simulador: " + e.getMessage(), true);
+        }
+    }
+
+    /**
+     * Maneja el evento del botón volver
+     *
      * @param event El evento de acción
      */
     @FXML

--- a/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/SimuladorMetasController.java
+++ b/src/main/java/es/franciscorodalf/saveinvestor/frontend/controller/SimuladorMetasController.java
@@ -1,0 +1,363 @@
+package es.franciscorodalf.saveinvestor.frontend.controller;
+
+import es.franciscorodalf.saveinvestor.backend.dao.ObjetivoDAO;
+import es.franciscorodalf.saveinvestor.backend.model.Objetivo;
+import es.franciscorodalf.saveinvestor.backend.model.Usuario;
+import es.franciscorodalf.saveinvestor.backend.service.PuntoProyeccion;
+import es.franciscorodalf.saveinvestor.backend.service.SimulacionMetaResultado;
+import es.franciscorodalf.saveinvestor.backend.service.SimuladorMetasService;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Controlador encargado de la vista del simulador de metas financieras.
+ */
+public class SimuladorMetasController {
+
+    @FXML
+    private ComboBox<Objetivo> comboObjetivos;
+    @FXML
+    private TextField txtMetaObjetivo;
+    @FXML
+    private TextField txtMontoInicial;
+    @FXML
+    private TextField txtAportacionPeriodica;
+    @FXML
+    private TextField txtTasaInteres;
+    @FXML
+    private Spinner<Integer> spinnerHorizonte;
+    @FXML
+    private TextField txtDescripcionEscenario;
+    @FXML
+    private LineChart<Number, Number> chartProyeccion;
+    @FXML
+    private NumberAxis axisMeses;
+    @FXML
+    private NumberAxis axisSaldo;
+    @FXML
+    private ProgressBar progressComparativa;
+    @FXML
+    private Label lblResumen;
+    @FXML
+    private Label lblComparativa;
+    @FXML
+    private Label lblEstado;
+    @FXML
+    private Button btnGuardarEscenario;
+    @FXML
+    private TextArea txtDetalles;
+
+    private final SimuladorMetasService simuladorMetasService = new SimuladorMetasService();
+    private final ObjetivoDAO objetivoDAO = new ObjetivoDAO();
+
+    private Usuario usuarioActual;
+    private Objetivo objetivoSeleccionado;
+    private SimulacionMetaResultado resultadoActual;
+    private String rutaRetorno;
+
+    @FXML
+    private void initialize() {
+        if (spinnerHorizonte != null) {
+            spinnerHorizonte.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, 600, 60));
+        }
+
+        if (comboObjetivos != null) {
+            comboObjetivos.setButtonCell(new ObjetivoListCell());
+            comboObjetivos.setCellFactory(listView -> new ObjetivoListCell());
+        }
+
+        if (chartProyeccion != null) {
+            chartProyeccion.setAnimated(false);
+        }
+
+        if (progressComparativa != null) {
+            progressComparativa.setProgress(0);
+        }
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuarioActual = usuario;
+        cargarObjetivosDelUsuario();
+    }
+
+    public void setRutaRetorno(String rutaRetorno) {
+        this.rutaRetorno = rutaRetorno;
+    }
+
+    @FXML
+    private void onSeleccionarObjetivo(ActionEvent event) {
+        objetivoSeleccionado = comboObjetivos.getValue();
+        if (objetivoSeleccionado == null) {
+            return;
+        }
+
+        txtMetaObjetivo.setText(String.format("%.2f", objetivoSeleccionado.getCantidadObjetivo()));
+        txtMontoInicial.setText(String.format("%.2f", objetivoSeleccionado.getCantidadActual()));
+
+        if (objetivoSeleccionado.getFechaObjetivo() != null) {
+            long meses = calcularMesesRestantes(objetivoSeleccionado.getFechaObjetivo());
+            spinnerHorizonte.getValueFactory().setValue((int) Math.max(1, meses));
+        }
+
+        txtDescripcionEscenario.setText(objetivoSeleccionado.getDescripcion() + " - Escenario");
+        actualizarComparativaActual();
+    }
+
+    @FXML
+    private void onSimular(ActionEvent event) {
+        try {
+            double montoInicial = parseDouble(txtMontoInicial.getText(), "monto inicial");
+            double aportacion = parseDouble(txtAportacionPeriodica.getText(), "aportación periódica");
+            double tasa = parseDouble(txtTasaInteres.getText(), "tasa de interés") / 100.0;
+            int horizonte = Optional.ofNullable(spinnerHorizonte.getValue()).orElse(1);
+            Double meta = txtMetaObjetivo.getText().isBlank() ? null : parseDouble(txtMetaObjetivo.getText(), "meta objetivo");
+
+            resultadoActual = simuladorMetasService.simular(montoInicial, aportacion, tasa, horizonte, meta);
+            actualizarGrafica(resultadoActual);
+            actualizarResumen(resultadoActual);
+            actualizarComparativaActual();
+            lblEstado.setText("Simulación generada correctamente");
+        } catch (NumberFormatException ex) {
+            mostrarError("Formato inválido", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            mostrarError("Datos inválidos", ex.getMessage());
+        }
+    }
+
+    @FXML
+    private void onCalcularAportacion(ActionEvent event) {
+        try {
+            double montoInicial = parseDouble(txtMontoInicial.getText(), "monto inicial");
+            double tasa = parseDouble(txtTasaInteres.getText(), "tasa de interés") / 100.0;
+            int horizonte = Optional.ofNullable(spinnerHorizonte.getValue()).orElse(1);
+            double meta = parseDouble(txtMetaObjetivo.getText(), "meta objetivo");
+
+            double aportacion = simuladorMetasService.calcularAportacionNecesaria(montoInicial, tasa, horizonte, meta);
+            txtAportacionPeriodica.setText(String.format("%.2f", aportacion));
+            lblEstado.setText("Aportación sugerida actualizada");
+        } catch (NumberFormatException ex) {
+            mostrarError("Formato inválido", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            mostrarError("Datos inválidos", ex.getMessage());
+        }
+    }
+
+    @FXML
+    private void onGuardarEscenario(ActionEvent event) {
+        if (usuarioActual == null) {
+            mostrarError("Acción no disponible", "Debe iniciar sesión para guardar escenarios");
+            return;
+        }
+        if (resultadoActual == null) {
+            mostrarError("Sin simulación", "Primero debe generar una simulación para guardar");
+            return;
+        }
+
+        String descripcion = txtDescripcionEscenario.getText() != null ? txtDescripcionEscenario.getText().trim() : "";
+        if (descripcion.isEmpty()) {
+            mostrarError("Descripción requerida", "Ingrese una descripción para el escenario");
+            return;
+        }
+
+        try {
+            double meta = parseDouble(txtMetaObjetivo.getText(), "meta objetivo");
+            Objetivo nuevoObjetivo = new Objetivo(descripcion, meta, usuarioActual.getId());
+            nuevoObjetivo.setCantidadActual(parseDouble(txtMontoInicial.getText(), "monto inicial"));
+
+            if (spinnerHorizonte.getValue() != null) {
+                LocalDate fechaObjetivo = LocalDate.now().plusMonths(spinnerHorizonte.getValue());
+                Date fecha = Date.from(fechaObjetivo.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                nuevoObjetivo.setFechaObjetivo(fecha);
+            }
+
+            objetivoDAO.insertar(nuevoObjetivo);
+            lblEstado.setText("Escenario guardado como objetivo");
+            cargarObjetivosDelUsuario();
+        } catch (NumberFormatException ex) {
+            mostrarError("Formato inválido", ex.getMessage());
+        } catch (SQLException ex) {
+            mostrarError("Error de base de datos", "No se pudo guardar el escenario: " + ex.getMessage());
+        }
+    }
+
+    @FXML
+    private void onVolver(ActionEvent event) {
+        String destino = rutaRetorno != null ? rutaRetorno : "/es/franciscorodalf/saveinvestor/main.fxml";
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource(destino));
+            Parent root = loader.load();
+
+            Object controller = loader.getController();
+            if (controller instanceof ObjetivosController objetivosController && usuarioActual != null) {
+                objetivosController.setUsuario(usuarioActual);
+            } else if (controller instanceof MainController mainController && usuarioActual != null) {
+                mainController.setUsuario(usuarioActual);
+            }
+
+            Stage stage = (Stage) ((Node) event.getSource()).getScene().getWindow();
+            stage.setScene(new Scene(root));
+            stage.show();
+        } catch (IOException e) {
+            mostrarError("Error de navegación", "No se pudo abrir la vista solicitada");
+        }
+    }
+
+    private void cargarObjetivosDelUsuario() {
+        if (usuarioActual == null || usuarioActual.getId() == null || comboObjetivos == null) {
+            return;
+        }
+        try {
+            List<Objetivo> objetivos = objetivoDAO.obtenerPorUsuario(usuarioActual.getId());
+            ObservableList<Objetivo> items = FXCollections.observableArrayList(objetivos);
+            comboObjetivos.setItems(items);
+        } catch (SQLException e) {
+            mostrarError("Error al cargar objetivos", e.getMessage());
+        }
+    }
+
+    private void actualizarGrafica(SimulacionMetaResultado resultado) {
+        if (chartProyeccion == null) {
+            return;
+        }
+        chartProyeccion.getData().clear();
+
+        XYChart.Series<Number, Number> proyeccion = new XYChart.Series<>();
+        proyeccion.setName("Proyección");
+        for (PuntoProyeccion punto : resultado.getPuntos()) {
+            proyeccion.getData().add(new XYChart.Data<>(punto.periodo(), punto.saldo()));
+        }
+        chartProyeccion.getData().add(proyeccion);
+
+        if (objetivoSeleccionado != null) {
+            XYChart.Series<Number, Number> actual = new XYChart.Series<>();
+            actual.setName("Saldo actual");
+            double saldoActual = objetivoSeleccionado.getCantidadActual();
+            int horizonte = resultado.getPuntos().get(resultado.getPuntos().size() - 1).periodo();
+            actual.getData().add(new XYChart.Data<>(0, saldoActual));
+            actual.getData().add(new XYChart.Data<>(horizonte, saldoActual));
+            chartProyeccion.getData().add(actual);
+        }
+    }
+
+    private void actualizarResumen(SimulacionMetaResultado resultado) {
+        if (resultado == null) {
+            lblResumen.setText("");
+            if (txtDetalles != null) {
+                txtDetalles.clear();
+            }
+            return;
+        }
+        StringBuilder resumen = new StringBuilder();
+        resumen.append(String.format("Saldo final proyectado: %.2f\n", resultado.getSaldoFinal()));
+        resumen.append(String.format("Total aportado: %.2f\n", resultado.getTotalAportado()));
+        resumen.append(String.format("Intereses generados: %.2f\n", resultado.getTotalIntereses()));
+        if (resultado.getPeriodoAlcanceMeta() != null) {
+            resumen.append(String.format("Meta alcanzada en %d meses.%n", resultado.getPeriodoAlcanceMeta()));
+        } else {
+            resumen.append("La meta no se alcanza en el horizonte simulado.\n");
+        }
+        lblResumen.setText(resumen.toString().strip());
+
+        if (txtDetalles != null) {
+            StringBuilder detalle = new StringBuilder();
+            for (PuntoProyeccion punto : resultado.getPuntos()) {
+                detalle.append(String.format("Mes %d - Saldo: %.2f | Aportado: %.2f | Intereses: %.2f%n",
+                        punto.periodo(), punto.saldo(), punto.aporteAcumulado(), punto.interesAcumulado()));
+            }
+            txtDetalles.setText(detalle.toString());
+        }
+    }
+
+    private void actualizarComparativaActual() {
+        if (progressComparativa == null) {
+            return;
+        }
+        double meta = 0;
+        double actual = 0;
+
+        if (objetivoSeleccionado != null) {
+            meta = objetivoSeleccionado.getCantidadObjetivo();
+            actual = objetivoSeleccionado.getCantidadActual();
+        } else if (resultadoActual != null && resultadoActual.getMetaObjetivo() != null) {
+            meta = resultadoActual.getMetaObjetivo();
+            actual = resultadoActual.getPuntos().isEmpty() ? 0 : resultadoActual.getPuntos().get(0).saldo();
+        }
+
+        if (resultadoActual != null) {
+            meta = resultadoActual.getMetaObjetivo() != null ? resultadoActual.getMetaObjetivo() : meta;
+        }
+
+        if (meta > 0) {
+            double progreso = actual / meta;
+            progressComparativa.setProgress(Math.min(1.0, progreso));
+            lblComparativa.setText(String.format("Progreso actual: %.2f%% de %.2f", progreso * 100, meta));
+        } else {
+            progressComparativa.setProgress(0);
+            lblComparativa.setText("Seleccione o defina una meta para comparar");
+        }
+    }
+
+    private long calcularMesesRestantes(Date fechaObjetivo) {
+        LocalDate hoy = LocalDate.now();
+        LocalDate fecha = fechaObjetivo.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        long meses = ChronoUnit.MONTHS.between(hoy.withDayOfMonth(1), fecha.withDayOfMonth(1));
+        return Math.max(1, meses);
+    }
+
+    private double parseDouble(String valor, String campo) {
+        try {
+            return Double.parseDouble(valor.replace(',', '.'));
+        } catch (NumberFormatException ex) {
+            throw new NumberFormatException("Ingrese un valor numérico válido para " + campo);
+        }
+    }
+
+    private void mostrarError(String titulo, String detalle) {
+        lblEstado.setText(detalle);
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setTitle(titulo);
+        alert.setHeaderText(titulo);
+        alert.setContentText(detalle);
+        alert.showAndWait();
+    }
+
+    private static class ObjetivoListCell extends javafx.scene.control.ListCell<Objetivo> {
+        @Override
+        protected void updateItem(Objetivo item, boolean empty) {
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setText(null);
+            } else {
+                setText(item.getDescripcion() + " (" + String.format("%.0f%%", item.calcularPorcentaje()) + ")");
+            }
+        }
+    }
+}

--- a/src/main/resources/es/franciscorodalf/saveinvestor/main.fxml
+++ b/src/main/resources/es/franciscorodalf/saveinvestor/main.fxml
@@ -68,6 +68,7 @@
             <Button fx:id="btnCerrarSesion" onAction="#onCerrarSesion" style="-fx-text-fill: #E74C3C;" text="Cerrar Sesión" />
             <Button fx:id="btnEstadisticas" onAction="#onEstadisticas" text="Estadísticas" />
             <Button fx:id="btnObjetivos" onAction="#onObjetivos" text="Objetivos" />
+            <Button fx:id="btnSimulador" onAction="#onSimulador" text="Simulador" />
         </HBox>
     </bottom>
 

--- a/src/main/resources/es/franciscorodalf/saveinvestor/objetivos.fxml
+++ b/src/main/resources/es/franciscorodalf/saveinvestor/objetivos.fxml
@@ -129,12 +129,15 @@
 
     <!-- Botón volver -->
     <bottom>
-        <HBox alignment="CENTER">
+        <HBox alignment="CENTER" spacing="15">
             <padding>
                 <Insets top="15" bottom="25" left="20" right="20"/>
             </padding>
-            <Button fx:id="btnVolver" text="Volver" onAction="#onVolver" 
-                    style="-fx-background-color: #e0e0e0; -fx-background-radius: 5; -fx-font-size: 14px;" 
+            <Button text="Simulador de metas" onAction="#onAbrirSimulador"
+                    style="-fx-background-color: #3498db; -fx-text-fill: white; -fx-background-radius: 5; -fx-font-size: 14px;"
+                    prefWidth="180" prefHeight="40"/>
+            <Button fx:id="btnVolver" text="Volver" onAction="#onVolver"
+                    style="-fx-background-color: #e0e0e0; -fx-background-radius: 5; -fx-font-size: 14px;"
                     prefWidth="120" prefHeight="40"/>
         </HBox>
     </bottom>

--- a/src/main/resources/es/franciscorodalf/saveinvestor/simuladorMetas.fxml
+++ b/src/main/resources/es/franciscorodalf/saveinvestor/simuladorMetas.fxml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.chart.LineChart?>
+<?import javafx.scene.chart.NumberAxis?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ProgressBar?>
+<?import javafx.scene.control.Spinner?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<BorderPane xmlns="http://javafx.com/javafx/23.0.1"
+            xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="es.franciscorodalf.saveinvestor.frontend.controller.SimuladorMetasController"
+            prefWidth="1000" prefHeight="650"
+            style="-fx-background-color: #f7f7f7;">
+    <top>
+        <HBox alignment="CENTER_LEFT" spacing="15">
+            <padding>
+                <Insets top="20" right="30" bottom="20" left="30"/>
+            </padding>
+            <Label text="Simulador de metas financieras"
+                   style="-fx-font-size: 24px; -fx-font-weight: bold;"/>
+        </HBox>
+    </top>
+
+    <center>
+        <VBox spacing="15">
+            <padding>
+                <Insets top="10" right="30" bottom="20" left="30"/>
+            </padding>
+
+            <VBox spacing="8" style="-fx-background-color: white; -fx-background-radius: 8; -fx-padding: 15;">
+                <Label text="¿Qué pasa si...? Usa tus objetivos o crea escenarios" style="-fx-font-weight: bold;"/>
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Importar objetivo:"/>
+                    <ComboBox fx:id="comboObjetivos" promptText="Selecciona un objetivo" prefWidth="280" onAction="#onSeleccionarObjetivo"/>
+                </HBox>
+            </VBox>
+
+            <GridPane hgap="10" vgap="12" style="-fx-background-color: white; -fx-background-radius: 8; -fx-padding: 20;">
+                <columnConstraints>
+                    <ColumnConstraints percentWidth="25"/>
+                    <ColumnConstraints percentWidth="25"/>
+                    <ColumnConstraints percentWidth="25"/>
+                    <ColumnConstraints percentWidth="25"/>
+                </columnConstraints>
+
+                <Label text="Meta objetivo" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                <TextField fx:id="txtMetaObjetivo" promptText="Monto total" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+
+                <Label text="Monto inicial" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                <TextField fx:id="txtMontoInicial" promptText="Capital disponible" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+
+                <Label text="Aportación mensual" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                <TextField fx:id="txtAportacionPeriodica" promptText="Cantidad ahorrada cada mes" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+
+                <Label text="Tasa interés anual (%)" GridPane.rowIndex="0" GridPane.columnIndex="2"/>
+                <TextField fx:id="txtTasaInteres" promptText="Ej: 5" GridPane.rowIndex="0" GridPane.columnIndex="3"/>
+
+                <Label text="Horizonte (meses)" GridPane.rowIndex="1" GridPane.columnIndex="2"/>
+                <Spinner fx:id="spinnerHorizonte" prefWidth="120" GridPane.rowIndex="1" GridPane.columnIndex="3"/>
+
+                <Label text="Descripción del escenario" GridPane.rowIndex="2" GridPane.columnIndex="2"/>
+                <TextField fx:id="txtDescripcionEscenario" promptText="Nombre identificativo" GridPane.rowIndex="2" GridPane.columnIndex="3"/>
+            </GridPane>
+
+            <HBox alignment="CENTER_LEFT" spacing="10">
+                <Button text="Calcular aportación" onAction="#onCalcularAportacion"/>
+                <Button text="Simular" style="-fx-background-color: #27ae60; -fx-text-fill: white;" onAction="#onSimular"/>
+                <Button fx:id="btnGuardarEscenario" text="Guardar escenario" onAction="#onGuardarEscenario"/>
+                <Label fx:id="lblEstado" textFill="#2c3e50" style="-fx-font-style: italic;"/>
+            </HBox>
+
+            <VBox spacing="15" style="-fx-background-color: white; -fx-background-radius: 8; -fx-padding: 20;">
+                <LineChart fx:id="chartProyeccion" prefHeight="280">
+                    <xAxis>
+                        <NumberAxis fx:id="axisMeses" label="Meses"/>
+                    </xAxis>
+                    <yAxis>
+                        <NumberAxis fx:id="axisSaldo" label="Saldo proyectado"/>
+                    </yAxis>
+                </LineChart>
+
+                <VBox spacing="8">
+                    <Label fx:id="lblResumen" style="-fx-font-size: 14px; -fx-font-weight: bold;" wrapText="true"/>
+                    <ProgressBar fx:id="progressComparativa" prefWidth="400"/>
+                    <Label fx:id="lblComparativa" text="Selecciona un objetivo para comparar"/>
+                </VBox>
+
+                <TextArea fx:id="txtDetalles" prefRowCount="6" wrapText="true" promptText="Detalle de la proyección"/>
+            </VBox>
+        </VBox>
+    </center>
+
+    <bottom>
+        <HBox alignment="CENTER_RIGHT">
+            <padding>
+                <Insets top="15" right="30" bottom="20" left="30"/>
+            </padding>
+            <Button text="Volver" onAction="#onVolver"/>
+        </HBox>
+    </bottom>
+</BorderPane>


### PR DESCRIPTION
## Summary
- add a backend service that produces savings projections with interest, periodic contributions, and reach estimates
- create the SimuladorMetas view/controller to run what-if scenarios, compare with current objectives, and persist scenarios
- wire navigation from the objectives screen and main menu so users can open the simulator directly

## Testing
- `mvn -q -DskipTests package` *(fails: blocked from downloading javafx-maven-plugin 0.0.8)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e44e68984832da238f717aeb81a71)